### PR TITLE
Pin immutable to 4.3.9 to fix Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "seriously-simple-transcripts",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "seriously-simple-transcripts",
-			"version": "1.1.1",
+			"version": "1.2.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/scripts": "^22.5.0",
@@ -9477,10 +9477,11 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-			"integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
-			"dev": true
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+			"integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -26885,9 +26886,9 @@
 			}
 		},
 		"immutable": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-			"integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+			"version": "4.3.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+			"integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -32259,7 +32260,7 @@
 			"dev": true,
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0",
-				"immutable": "^4.0.0",
+				"immutable": "4.3.9",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^22.5.0",
 		"npm": "^10.2.0"
+	},
+	"overrides": {
+		"immutable": "4.3.9"
 	}
 }


### PR DESCRIPTION
## Summary
- Pins the transitive `immutable` dependency (via `sass` / `@wordpress/scripts`) to 4.3.9 with an npm override.
- Closes the open Dependabot alerts for prototype pollution (GHSA-wf6x-7x77-mvgw) and two DoS issues (GHSA-v56q-mh7h-f735, GHSA-xvcm-6775-5m9r).

## Test plan
- [ ] Confirm `npm ls immutable` reports `immutable@4.3.9 overridden`
- [ ] Confirm `npm audit` no longer reports `immutable`
- [ ] After merge, confirm the three Dependabot alerts close on GitHub


Made with [Cursor](https://cursor.com)